### PR TITLE
Add button to Token Control sidebar

### DIFF
--- a/progress-countdown-tracker.js
+++ b/progress-countdown-tracker.js
@@ -980,3 +980,30 @@ class ProgressCountdownTrackerApp extends foundry.applications.api.HandlebarsApp
   }*/
 
 }
+
+Hooks.on("getSceneControlButtons", function(controls) {
+  let tileControls = controls['tokens'];
+
+  tileControls.tools['open-progress-trackers'] = {
+    icon: 'fas fa-list-timeline',
+    name: 'open-progress-trackers',
+    title: 'Open Progress Trackers',
+    button: true,
+    onChange: (value) => {
+      if(!pcTracker) {
+        pcTracker = new ProgressCountdownTrackerApp();
+      }
+      if(value && !pcTracker.rendered) {
+        game.pcTracker.render(true);
+        //console.log(pcTracker.rendered);
+        //console.log("visible setting:", game.settings.get("progress-countdown-tracker", "trackerVisible"));
+      } else {
+        game.pcTracker.close();
+        //console.log(pcTracker.rendered);
+        //console.log("visible setting:", game.settings.get("progress-countdown-tracker", "trackerVisible"));
+      }
+    },
+    visible: true,
+  };
+
+});


### PR DESCRIPTION
Adds button to Token Control sidebar to quickly re-open the tracker if closed.
![Foundry_Virtual_Tabletop_2025-09-16_17-11-44](https://github.com/user-attachments/assets/09c07024-fd13-4b21-bbd4-a89b5123d5ec)
